### PR TITLE
Add pow and abs operators to Interval

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 test=pytest
 
 [tool:pytest]
-addopts = --cov suspect --cov-report=html --cov-report=term
+addopts = --cov suspect --cov-report=html --cov-report=term --reruns 5
 
 [coverage:report]
 exclude_lines =

--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,5 @@ setup(
         'boto3>=1.7.4',
     ],
     setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'pytest-cov', 'hypothesis'],
+    tests_require=['pytest', 'pytest-cov', 'hypothesis', 'pytest-rerunfailures'],
 )

--- a/suspect/__version__.py
+++ b/suspect/__version__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 __author__ = 'Francesco Ceccon'
 __author_email__ = 'francesco@ceccon.me'
 __license__ = 'Apache 2.0'

--- a/suspect/interval.py
+++ b/suspect/interval.py
@@ -263,6 +263,13 @@ class Interval(object): # pylint: disable=too-many-public-methods
 
     __rtruediv__ = __rdiv__
 
+    def __abs__(self):
+        if almostgte(self.lower_bound, 0):
+            return self
+        if almostlte(self.upper_bound, 0):
+            return -self
+        return Interval(0, up(lambda: max_(-self.lower_bound, self.upper_bound)))
+
     def __pow__(self, pow_):
         # Rules and tests from Boost::interval
         if isinstance(pow_, Interval):

--- a/suspect/math/__init__.py
+++ b/suspect/math/__init__.py
@@ -93,6 +93,7 @@ _COMMON_MEMBERS = [
     'sqrt',
     'log',
     'exp',
+    'power',
     'sin',
     'asin',
     'cos',

--- a/suspect/math/arbitrary_precision.py
+++ b/suspect/math/arbitrary_precision.py
@@ -25,13 +25,23 @@ pi = mpmath.pi
 isnan = mpmath.isnan
 
 
-def _declare_function(name, fun):
+def _declare_unary_function(name, fun):
+    # skip rounding mode since we don't round
     globals()[name] = lambda n, _: fun(n)
 
 
-_FUNCTIONS = ['sqrt', 'log', 'exp', 'sin', 'asin', 'cos', 'acos', 'tan', 'atan']
-for fun in _FUNCTIONS:
-    _declare_function(fun, getattr(mpmath, fun))
+def _declare_binary_function(name, fun):
+    # skip rounding mode since we don't round
+    globals()[name] = lambda x, y, _: fun(x, y)
+
+
+_UNARY_FUNCTIONS = ['sqrt', 'log', 'exp', 'sin', 'asin', 'cos', 'acos', 'tan', 'atan']
+for fun in _UNARY_FUNCTIONS:
+    _declare_unary_function(fun, getattr(mpmath, fun))
+
+_BINARY_FUNCTIONS = ['power']
+for fun in _BINARY_FUNCTIONS:
+    _declare_binary_function(fun, getattr(mpmath, fun))
 
 
 def down(f):

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -192,3 +192,26 @@ class TestSize(object):
     def test_finite_bounds_1(self, a, f):
         b = a * f
         assert almostgte(a.size(), b.size())
+
+
+class TestPower(object):
+    @pytest.mark.parametrize('base,p,expected', [
+        (Interval(2, 3), 3, Interval(8, 27)),
+        (Interval(2, 3), 4, Interval(16, 81)),
+        (Interval(-3, 2), 3, Interval(-27, 8)),
+        (Interval(-3, 2), 4, Interval(0, 81)),
+        (Interval(-3, -2), 3, Interval(-27, -8)),
+        (Interval(-3, -2), 4, Interval(16, 81)),
+
+        (Interval(2, 4), -3, Interval(1.0/64.0, 1.0/8.0)),
+        (Interval(2, 4), -4, Interval(1.0/256.0, 1.0/16.0)),
+        (Interval(-4, -2), -3, Interval(-1.0/8.0, -1.0/64.0)),
+        (Interval(-4, -2), -4, Interval(1.0/256.0, 1.0/16.0)),
+
+        (Interval(2, 3), 0, Interval(1, 1)),
+        (Interval(-3, 2), 0, Interval(1, 1)),
+        (Interval(-3, -2), 0, Interval(1, 1)),
+    ])
+    def test_power(self, base, p, expected):
+        result = base ** p
+        assert expected == result

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -194,6 +194,17 @@ class TestSize(object):
         assert almostgte(a.size(), b.size())
 
 
+class TestAbs(object):
+    @pytest.mark.parametrize('it,expected', [
+        (Interval(1, 2), Interval(1, 2)),
+        (Interval(-3, -2), Interval(2, 3)),
+        (Interval(-3, 2), Interval(0, 3)),
+        (Interval(-2, 3), Interval(0, 3)),
+    ])
+    def test_abs(self, it, expected):
+        assert expected == abs(it)
+
+
 class TestPower(object):
     @pytest.mark.parametrize('base,p,expected', [
         (Interval(2, 3), 3, Interval(8, 27)),


### PR DESCRIPTION
`Interval` at the moment does not support all possible operators, this PR adds 2 more: `abs` and `**`. The power operator only works with integers, in the future we can improve it from `x^y <=> exp{y ln(x)}`.