### PR TITLE
find component is more robust with components than strings

### DIFF
--- a/suspect/pyomo/connected_model.py
+++ b/suspect/pyomo/connected_model.py
@@ -23,16 +23,16 @@ def create_connected_model(model, active=True, connect_max_linear_children=50, c
     components = ExpressionDict(float_hasher=BTreeFloatHasher())
 
     for var in model.component_data_objects(pyo.Var, active=active, sort=True, descend_into=True):
-        connected_var = connected.find_component(var.getname(fully_qualified=True))
+        connected_var = connected.find_component(var)
         model_to_connected_map[var] = connected_var
         components[connected_var] = connected_var
 
     for constraint in model.component_data_objects(pyo.Constraint, active=active, sort=True, descend_into=True):
-        connected_constraint = connected.find_component(constraint.getname(fully_qualified=True))
+        connected_constraint = connected.find_component(constraint)
         model_to_connected_map[constraint] = connected_constraint
 
     for objective in model.component_data_objects(pyo.Objective, active=active, sort=True, descend_into=True):
-        connected_objective = connected.find_component(objective.getname(fully_qualified=True))
+        connected_objective = connected.find_component(objective)
         model_to_connected_map[objective] = connected_objective
 
     convert_visitor = _ConvertExpressionVisitor(


### PR DESCRIPTION
consider

```
import pyomo.environ as pe
m = pe.ConcreteModel()
m.x = pe.Var(['1', '2'])
```

The following does not work:
```
m2 = m.clone()
m2.find_component(m.x['1'].getname(fully_qualified=True)) is m2.x['1']  # False
```

However, the following does
```
m2 = m.clone()
m2.find_component(m.x['1']) is m2.x['1']  # True
```

The reason the former does not work is that `m.x['1'].getname(fully_qualified=True)` returns `"m.x[1]"` instead of `"m.x['1']"`.