### PR TITLE
Fix Tests and Update Badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,12 @@
 Special Structure Detection for Pyomo
 =====================================
 
-|DOI|_ |travis|_ |codecov|_
+|DOI|_ |GHA|_ |codecov|_
 
 .. |DOI| image:: https://zenodo.org/badge/127118649.svg
 .. _DOI: https://zenodo.org/badge/latestdoi/127118649
-.. |travis| image:: https://travis-ci.org/cog-imperial/suspect.svg?branch=master
-.. _travis: https://travis-ci.org/cog-imperial/suspect
+.. |GHA| image:: https://github.com/cog-imperial/suspect/actions/workflows/main.yml/badge.svg
+.. _GHA: https://github.com/cog-imperial/suspect/actions/workflows/main.yml
 .. |codecov| image:: https://codecov.io/gh/cog-imperial/suspect/branch/master/graph/badge.svg
 .. _codecov: https://codecov.io/gh/cog-imperial/suspect
 

--- a/suspect/math/floating_point.py
+++ b/suspect/math/floating_point.py
@@ -70,7 +70,7 @@ def max_(*args):
     return max(a for a in args if not isnan(a))
 
 
-def almosteq(a, b, rel_eps=1e-5, abs_eps=1e-8):
+def almosteq(a, b, rel_eps=1e-6, abs_eps=1e-8):
     """Floating point equality check between `a` and `b`."""
     if type(a) in float_int and type(b) in float_int:
         return math.isclose(a, b, rel_tol=rel_eps, abs_tol=abs_eps)


### PR DESCRIPTION
1. Fix the failing tests by tightening the tolerance in `almosteq`. 
2. Update the badges to point to GHA instead of Travis